### PR TITLE
[Repo Assist] perf: cache Azure data in web app to avoid redundant round-trips

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,8 @@
       "Bash(powershell:*)",
       "Bash(dotnet fantomas:*)",
       "Bash(gh pr:*)",
-      "Bash(dotnet test:*)"
+      "Bash(dotnet test:*)",
+      "Bash(gh api:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,8 +12,7 @@
       "Bash(powershell:*)",
       "Bash(dotnet fantomas:*)",
       "Bash(gh pr:*)",
-      "Bash(dotnet test:*)",
-      "Bash(gh api:*)"
+      "Bash(dotnet test:*)"
     ],
     "deny": [],
     "ask": []

--- a/BeerTaste.Web/Program.fs
+++ b/BeerTaste.Web/Program.fs
@@ -41,7 +41,15 @@ type DataCache(storage: BeerTasteTableStorage, cache: IMemoryCache) =
         getOrCreate $"scores:{beerTasteGuid}" (fun () -> Scores.fetchScores storage beerTasteGuid)
 
     member _.FetchBeerTaste(beerTasteGuid: string) =
-        BeerTasteStorage.fetchBeerTaste storage beerTasteGuid
+        let key = $"beertaste:{beerTasteGuid}"
+        match cache.TryGetValue(key) with
+        | true, (:? BeerTaste as beerTaste) -> Some beerTaste
+        | _ ->
+             let result = BeerTasteStorage.fetchBeerTaste storage beerTasteGuid
+             match result with
+             | Some beerTaste ->
+                 cache.Set(key, beerTaste, ttl) |> Some
+             | None -> None
 
 let notFound (s: string) : EndpointHandler = setStatusCode 404 >=> text s
 

--- a/BeerTaste.Web/Program.fs
+++ b/BeerTaste.Web/Program.fs
@@ -1,6 +1,8 @@
-﻿open System.Threading.Tasks
+﻿open System
+open System.Threading.Tasks
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.Caching.Memory
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.Logging
@@ -12,6 +14,34 @@ open BeerTaste.Web.Templates
 open BeerTaste.Web.Localization
 
 type SecretsAnchor = class end
+
+/// Cache Azure Table Storage data per beerTasteGuid.
+/// Tasting event data is immutable during an event, so caching avoids redundant
+/// Azure round-trips when a user navigates between result pages.
+type DataCache(storage: BeerTasteTableStorage, cache: IMemoryCache) =
+    let ttl = TimeSpan.FromMinutes(10.0)
+
+    let getOrCreate (key: string) (fetch: unit -> 'T) : 'T =
+        match cache.TryGetValue(key) with
+        | true, (:? 'T as value) -> value
+        | _ ->
+            let result = fetch ()
+            use entry = cache.CreateEntry(key)
+            entry.AbsoluteExpirationRelativeToNow <- ttl
+            entry.Value <- result
+            result
+
+    member _.FetchBeers(beerTasteGuid: string) =
+        getOrCreate $"beers:{beerTasteGuid}" (fun () -> Beers.fetchBeers storage beerTasteGuid)
+
+    member _.FetchTasters(beerTasteGuid: string) =
+        getOrCreate $"tasters:{beerTasteGuid}" (fun () -> Tasters.fetchTasters storage beerTasteGuid)
+
+    member _.FetchScores(beerTasteGuid: string) =
+        getOrCreate $"scores:{beerTasteGuid}" (fun () -> Scores.fetchScores storage beerTasteGuid)
+
+    member _.FetchBeerTaste(beerTasteGuid: string) =
+        BeerTasteStorage.fetchBeerTaste storage beerTasteGuid
 
 let notFound (s: string) : EndpointHandler = setStatusCode 404 >=> text s
 
@@ -29,142 +59,142 @@ let resultsIndex (beerTasteGuid: string) : EndpointHandler =
         |> htmlView
         <| ctx
 
-let bestBeers (storage: BeerTasteTableStorage) (beerTasteGuid: string) : EndpointHandler =
+let bestBeers (dc: DataCache) (beerTasteGuid: string) : EndpointHandler =
     fun ctx ->
         let language = getLanguage ctx
-        let beers = Beers.fetchBeers storage beerTasteGuid
-        let scores = Scores.fetchScores storage beerTasteGuid
+        let beers = dc.FetchBeers beerTasteGuid
+        let scores = dc.FetchScores beerTasteGuid
         let results = Results.beerAverages beers scores
 
         BestBeers.view beerTasteGuid language results
         |> htmlView
         <| ctx
 
-let controversial (storage: BeerTasteTableStorage) (beerTasteGuid: string) : EndpointHandler =
+let controversial (dc: DataCache) (beerTasteGuid: string) : EndpointHandler =
     fun ctx ->
         let language = getLanguage ctx
-        let beers = Beers.fetchBeers storage beerTasteGuid
-        let scores = Scores.fetchScores storage beerTasteGuid
+        let beers = dc.FetchBeers beerTasteGuid
+        let scores = dc.FetchScores beerTasteGuid
         let results = Results.beerStandardDeviations beers scores
 
         Controversial.view beerTasteGuid language results
         |> htmlView
         <| ctx
 
-let deviant (storage: BeerTasteTableStorage) (beerTasteGuid: string) : EndpointHandler =
+let deviant (dc: DataCache) (beerTasteGuid: string) : EndpointHandler =
     fun ctx ->
         let language = getLanguage ctx
-        let beers = Beers.fetchBeers storage beerTasteGuid
-        let tasters = Tasters.fetchTasters storage beerTasteGuid
-        let scores = Scores.fetchScores storage beerTasteGuid
+        let beers = dc.FetchBeers beerTasteGuid
+        let tasters = dc.FetchTasters beerTasteGuid
+        let scores = dc.FetchScores beerTasteGuid
         let results = Results.correlationToAverages beers tasters scores
 
         Deviant.view beerTasteGuid language results
         |> htmlView
         <| ctx
 
-let similar (storage: BeerTasteTableStorage) (beerTasteGuid: string) : EndpointHandler =
+let similar (dc: DataCache) (beerTasteGuid: string) : EndpointHandler =
     fun ctx ->
         let language = getLanguage ctx
-        let tasters = Tasters.fetchTasters storage beerTasteGuid
-        let scores = Scores.fetchScores storage beerTasteGuid
+        let tasters = dc.FetchTasters beerTasteGuid
+        let scores = dc.FetchScores beerTasteGuid
         let results = Results.correlationBetweenTasters tasters scores
 
         Similar.view beerTasteGuid language results
         |> htmlView
         <| ctx
 
-let strongBeers (storage: BeerTasteTableStorage) (beerTasteGuid: string) : EndpointHandler =
+let strongBeers (dc: DataCache) (beerTasteGuid: string) : EndpointHandler =
     fun ctx ->
         let language = getLanguage ctx
-        let beers = Beers.fetchBeers storage beerTasteGuid
-        let tasters = Tasters.fetchTasters storage beerTasteGuid
-        let scores = Scores.fetchScores storage beerTasteGuid
+        let beers = dc.FetchBeers beerTasteGuid
+        let tasters = dc.FetchTasters beerTasteGuid
+        let scores = dc.FetchScores beerTasteGuid
         let results = Results.correlationToAbv beers tasters scores
 
         StrongBeers.view beerTasteGuid language results
         |> htmlView
         <| ctx
 
-let cheapAlcohol (storage: BeerTasteTableStorage) (beerTasteGuid: string) : EndpointHandler =
+let cheapAlcohol (dc: DataCache) (beerTasteGuid: string) : EndpointHandler =
     fun ctx ->
         let language = getLanguage ctx
-        let beers = Beers.fetchBeers storage beerTasteGuid
-        let tasters = Tasters.fetchTasters storage beerTasteGuid
-        let scores = Scores.fetchScores storage beerTasteGuid
+        let beers = dc.FetchBeers beerTasteGuid
+        let tasters = dc.FetchTasters beerTasteGuid
+        let scores = dc.FetchScores beerTasteGuid
         let results = Results.correlationToAbvPrice beers tasters scores
 
         CheapAlcohol.view beerTasteGuid language results
         |> htmlView
         <| ctx
 
-let oldManBeers (storage: BeerTasteTableStorage) (beerTasteGuid: string) : EndpointHandler =
+let oldManBeers (dc: DataCache) (beerTasteGuid: string) : EndpointHandler =
     fun ctx ->
         let language = getLanguage ctx
-        let beers = Beers.fetchBeers storage beerTasteGuid
-        let tasters = Tasters.fetchTasters storage beerTasteGuid
-        let scores = Scores.fetchScores storage beerTasteGuid
+        let beers = dc.FetchBeers beerTasteGuid
+        let tasters = dc.FetchTasters beerTasteGuid
+        let scores = dc.FetchScores beerTasteGuid
         let results = Results.correlationToAge beers tasters scores
 
         OldManBeers.view beerTasteGuid language results
         |> htmlView
         <| ctx
 
-let beersView (storage: BeerTasteTableStorage) (beerTasteGuid: string) : EndpointHandler =
+let beersView (dc: DataCache) (beerTasteGuid: string) : EndpointHandler =
     fun ctx ->
         let language = getLanguage ctx
-        let beers = Beers.fetchBeers storage beerTasteGuid
+        let beers = dc.FetchBeers beerTasteGuid
 
         BeersView.view beerTasteGuid language beers
         |> htmlView
         <| ctx
 
-let tastersView (storage: BeerTasteTableStorage) (beerTasteGuid: string) : EndpointHandler =
+let tastersView (dc: DataCache) (beerTasteGuid: string) : EndpointHandler =
     fun ctx ->
         let language = getLanguage ctx
-        let tasters = Tasters.fetchTasters storage beerTasteGuid
+        let tasters = dc.FetchTasters beerTasteGuid
 
         TastersView.view beerTasteGuid language tasters
         |> htmlView
         <| ctx
 
-let scoresView (storage: BeerTasteTableStorage) (beerTasteGuid: string) : EndpointHandler =
+let scoresView (dc: DataCache) (beerTasteGuid: string) : EndpointHandler =
     fun ctx ->
         let language = getLanguage ctx
-        let beers = Beers.fetchBeers storage beerTasteGuid
-        let tasters = Tasters.fetchTasters storage beerTasteGuid
-        let scores = Scores.fetchScores storage beerTasteGuid
+        let beers = dc.FetchBeers beerTasteGuid
+        let tasters = dc.FetchTasters beerTasteGuid
+        let scores = dc.FetchScores beerTasteGuid
 
         ScoresView.view beerTasteGuid language beers tasters scores
         |> htmlView
         <| ctx
 
-let beerTasteView (storage: BeerTasteTableStorage) (beerTasteGuid: string) : EndpointHandler =
+let beerTasteView (dc: DataCache) (beerTasteGuid: string) : EndpointHandler =
     fun ctx ->
         let language = getLanguage ctx
 
-        match BeerTasteStorage.fetchBeerTaste storage beerTasteGuid with
+        match dc.FetchBeerTaste beerTasteGuid with
         | Some beerTaste ->
             BeerTasteView.view beerTaste language |> htmlView
             <| ctx
         | None -> "BeerTaste not found" |> notFound <| ctx
 
 
-let endpoints storage = [
+let endpoints (dc: DataCache) = [
     GET [
         route "/" <| homepage
         routef "/{%s}/results" resultsIndex
-        routef "/{%s}/results/bestbeers" (bestBeers storage)
-        routef "/{%s}/results/controversial" (controversial storage)
-        routef "/{%s}/results/deviant" (deviant storage)
-        routef "/{%s}/results/strongbeers" (strongBeers storage)
-        routef "/{%s}/results/similar" (similar storage)
-        routef "/{%s}/results/cheapalcohol" (cheapAlcohol storage)
-        routef "/{%s}/results/oldmanbeers" (oldManBeers storage)
-        routef "/{%s}/beers" (beersView storage)
-        routef "/{%s}/tasters" (tastersView storage)
-        routef "/{%s}/scores" (scoresView storage)
-        routef "/{%s}" (beerTasteView storage)
+        routef "/{%s}/results/bestbeers" (bestBeers dc)
+        routef "/{%s}/results/controversial" (controversial dc)
+        routef "/{%s}/results/deviant" (deviant dc)
+        routef "/{%s}/results/strongbeers" (strongBeers dc)
+        routef "/{%s}/results/similar" (similar dc)
+        routef "/{%s}/results/cheapalcohol" (cheapAlcohol dc)
+        routef "/{%s}/results/oldmanbeers" (oldManBeers dc)
+        routef "/{%s}/beers" (beersView dc)
+        routef "/{%s}/tasters" (tastersView dc)
+        routef "/{%s}/scores" (scoresView dc)
+        routef "/{%s}" (beerTasteView dc)
     ]
 ]
 
@@ -206,8 +236,8 @@ let errorHandler (ctx: HttpContext) (next: RequestDelegate) : Task =
             return! ctx.WriteHtmlView(errorView 500 (string ex) language)
     }
 
-let configureApp (appBuilder: WebApplication) storage =
-    appBuilder.Use(errorHandler).UseStaticFiles().UseRouting().UseOxpecker(endpoints storage)
+let configureApp (appBuilder: WebApplication) (dc: DataCache) =
+    appBuilder.Use(errorHandler).UseStaticFiles().UseRouting().UseOxpecker(endpoints dc)
     |> ignore
 
 [<EntryPoint>]
@@ -216,7 +246,7 @@ let main args =
 
     let config = builder.Configuration.AddUserSecrets<SecretsAnchor>().AddEnvironmentVariables().Build()
 
-    builder.Services.AddRouting().AddOxpecker()
+    builder.Services.AddRouting().AddOxpecker().AddMemoryCache()
     |> ignore
 
     let app = builder.Build()
@@ -234,6 +264,8 @@ let main args =
         1
     | Some connStr ->
         let storage = BeerTasteTableStorage(connStr)
-        configureApp app storage
+        let cache = app.Services.GetRequiredService<IMemoryCache>()
+        let dc = DataCache(storage, cache)
+        configureApp app dc
         app.Run()
         0

--- a/BeerTaste.Web/Program.fs
+++ b/BeerTaste.Web/Program.fs
@@ -26,10 +26,7 @@ type DataCache(storage: BeerTasteTableStorage, cache: IMemoryCache) =
         | true, (:? 'T as value) -> value
         | _ ->
             let result = fetch ()
-            use entry = cache.CreateEntry(key)
-            entry.AbsoluteExpirationRelativeToNow <- ttl
-            entry.Value <- result
-            result
+            cache.Set(key, result, ttl)
 
     member _.FetchBeers(beerTasteGuid: string) =
         getOrCreate $"beers:{beerTasteGuid}" (fun () -> Beers.fetchBeers storage beerTasteGuid)
@@ -41,15 +38,7 @@ type DataCache(storage: BeerTasteTableStorage, cache: IMemoryCache) =
         getOrCreate $"scores:{beerTasteGuid}" (fun () -> Scores.fetchScores storage beerTasteGuid)
 
     member _.FetchBeerTaste(beerTasteGuid: string) =
-        let key = $"beertaste:{beerTasteGuid}"
-        match cache.TryGetValue(key) with
-        | true, (:? BeerTaste as beerTaste) -> Some beerTaste
-        | _ ->
-             let result = BeerTasteStorage.fetchBeerTaste storage beerTasteGuid
-             match result with
-             | Some beerTaste ->
-                 cache.Set(key, beerTaste, ttl) |> Some
-             | None -> None
+        getOrCreate $"beertaste:{beerTasteGuid}" (fun () -> BeerTasteStorage.fetchBeerTaste storage beerTasteGuid)
 
 let notFound (s: string) : EndpointHandler = setStatusCode 404 >=> text s
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ BeerTaste is an F# data analysis system for organizing and analyzing beer tastin
 - EPPlus 8.3.0 for Excel I/O (licensed for non-commercial personal use)
 - FSharp.Stats 0.6.0 for statistical analysis
 - Azure.Data.Tables 12.11.0 for Azure Table Storage integration
-- Oxpecker 1.5.0 for web presentation (F# web framework)
+- Oxpecker 2.0.0 for web presentation (F# web framework)
 - Spectre.Console 0.54.0 for CLI interactions
 - Fantomas 7.0.3 for code formatting
 - FsToolkit.ErrorHandling 5.1.0 for computation expressions (option workflow)
@@ -262,6 +262,7 @@ Separate **layered F# script architecture** for analysis:
 
 - ASP.NET Core with Oxpecker framework
 - **Fully implemented** results presentation with 7 statistical analysis pages and 4 data view pages
+- **Caching:** `DataCache` class wraps `BeerTasteTableStorage` with `IMemoryCache` (10-minute TTL) to avoid redundant Azure round-trips when users navigate between result pages
 - **Localization:** Complete English/Norwegian translations via Localization.fs
   - Language detection from cookies and Accept-Language header
   - Language selector in navigation bar
@@ -283,7 +284,7 @@ Separate **layered F# script architecture** for analysis:
   - **Scores Table** - Complete score matrix
   - **Event Details** - BeerTaste event information
 - Navigation with previous/next arrows between pages
-- Fetches data from Azure Table Storage via BeerTaste.Common
+- Fetches data from Azure Table Storage via BeerTaste.Common, cached by `DataCache` using `IMemoryCache`
 
 **Project Dependencies:**
 
@@ -450,7 +451,7 @@ Console → Excel Files → Scripts (analysis) → Reports/Slides
 ### Web Application
 
 - `BeerTaste.Web/Localization.fs` - English/Norwegian translations (`Language` DU, `Translations` record, `getTranslations`, `getLanguage`, `languageFromCode`)
-- `BeerTaste.Web/Program.fs` - Web application entry point with routing and data fetching
+- `BeerTaste.Web/Program.fs` - Web application entry point with routing, `DataCache` (in-memory caching layer), and data fetching
 - `BeerTaste.Web/templates/Layout.fs` - Shared page layout with black and white theme, language selector, Noto Color Emoji font
 - `BeerTaste.Web/templates/Navigation.fs` - Navigation between result pages with prev/next arrows (`ResultPage` DU, `allPages`, `pageToRoute`, `pageToIcon`)
 - `BeerTaste.Web/templates/ResultsIndex.fs` - Results hub page with icons for each result type
@@ -579,5 +580,6 @@ Where the administrator (me) adds all the scores given by the tasters. These are
 - Black and white theme with responsive layout and Noto Color Emoji font
 - Navigation with Unicode arrows (← →) between pages
 - Icons for each result type (★, ⚡, 😈, ❤, 😵, 💰, 👴)
+- **Caching:** `DataCache` class uses `IMemoryCache` with 10-minute TTL to cache Azure data per `beerTasteGuid`, registered via `AddMemoryCache()` in DI
 - Auto-opens in browser when Console detects complete scores
 - Text files need to use CRLF for line endings

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,215 @@
+# BeerTaste: Evolution to Interactive Web Application
+
+## Context
+
+BeerTaste is currently a read-only web app that displays beer tasting results, paired with a Console app that handles all data entry (creating events, adding beers/tasters, entering scores). The long-term goal is to become a **web-only, Kahoot-style interactive beer tasting platform** where tasters score beers on their own devices in real-time. The Console project will eventually be removed.
+
+Authentication will use **Firebase** (Google OAuth + email login), following the same pattern as the HabitTeller repo. The branch `copilot/add-login-widget-feature` already has client-side Firebase auth wired up (login widget, Google sign-in popup, all templates updated with `firebaseConfig` parameter threading). This plan builds on that work.
+
+This plan is incremental — each step is independently deployable. Only the first ~5 tasks are detailed; later tasks are broad.
+
+---
+
+## Existing Work (branch `copilot/add-login-widget-feature`)
+
+Already done on this branch:
+- `FirebaseConfig` type in `Localization.fs` (ApiKey, AuthDomain, ProjectId)
+- Firebase SDK v10.7.1 loaded in `Layout.fs` with `onAuthStateChanged` listener
+- Google sign-in popup via `firebaseScripts` function
+- Login widget in nav bar across all pages
+- All 12 templates updated to accept `firebaseConfig` parameter
+- CSS for login widget (black & white theme)
+- EN/NO translations for Login/Logout
+- README with Firebase setup instructions
+- Config via user-secrets: `BeerTaste:Firebase:ApiKey`, `AuthDomain`, `ProjectId`
+
+**Not done yet:** Server-side token validation, sessions, Users table, protected routes, any write endpoints.
+
+---
+
+## Phase 1: Foundation — Server-Side Auth (builds on existing branch)
+
+### Task 1: Move BeerTasteTableStorage and DataCache into DI
+
+Pure refactor. Currently these are manually instantiated in `main` and threaded through as parameters. Moving them to DI is prerequisite for auth middleware and new services.
+
+**Modify `BeerTaste.Web/Program.fs`:**
+- Register `BeerTasteTableStorage` as singleton (from connection string config)
+- Register `DataCache` as singleton (depends on storage + IMemoryCache)
+- Remove `dc` / `storage` parameters from `endpoints` and `configureApp`
+- Each handler resolves `DataCache` via `ctx.GetService<DataCache>()`
+
+No user-visible changes.
+
+### Task 2: Add Users, Sessions tables and server-side auth middleware
+
+Follow the HabitTeller pattern: Firebase ID tokens are exchanged for server-side sessions stored in Azure Table Storage.
+
+**Add `FirebaseAdmin` NuGet package** to `BeerTaste.Web/BeerTaste.Web.fsproj`
+
+**Create `BeerTaste.Common/Users.fs`** (new file, add to `.fsproj` between `BeerTaste.fs` and `Scores.fs`):
+- `User` record: `AuthenticationScheme: string`, `AccountId: string` (Firebase UID), `UserId: Guid`, `Name: string`
+- Entity conversion: PartitionKey = AuthenticationScheme (e.g. `"Firebase"`), RowKey = AccountId
+- `addUser`, `fetchUser`, `getOrCreateUser`
+
+**Create `BeerTaste.Common/Sessions.fs`** (new file, after Users.fs):
+- `Session` record: `SessionId: Guid`, `UserId: Guid`, `AccountId: string`, `AuthScheme: string`, `Name: string`, `LastActiveAt: DateTimeOffset`
+- Entity conversion: PartitionKey = first 8 chars of SessionId, RowKey = full SessionId
+- `addSession`, `fetchSession`, `deleteSession`, `updateLastActiveAt`
+- Session expiry: 90 days, update `LastActiveAt` only if >1 hour old
+
+**Modify `BeerTaste.Common/Storage.fs`:**
+- Add `UsersTableClient` and `SessionsTableClient` (tables: `"users"`, `"sessions"`)
+
+**Create `BeerTaste.Web/FirebaseAuth.fs`** (before Program.fs in compilation):
+- `FirebaseServerConfig` type: `ProjectId`, optional `ServiceAccountKeyPath`
+- `initialize()`: sets up FirebaseAdmin SDK
+- `verifyIdToken(token)`: validates Firebase ID token, returns claims
+
+**Create `BeerTaste.Web/AuthMiddleware.fs`** (after FirebaseAuth.fs):
+- Custom middleware following HabitTeller pattern:
+  - Path 1: `Authorization: Bearer <token>` → verify with Firebase → get/create user → set in `HttpContext.Items`
+  - Path 2: `session` cookie → lookup in sessions table → validate expiry → set user in `HttpContext.Items`
+- Helper: `getCurrentUser(ctx)` returns `User option`
+
+**Modify `BeerTaste.Web/Program.fs`:**
+- Add auth middleware to pipeline
+- Add `POST /auth/session` endpoint: accepts Firebase ID token, creates session, sets HttpOnly cookie
+- Add `POST /auth/logout` endpoint: deletes session, clears cookie
+- Initialize Firebase Admin SDK on startup
+
+### Task 3: Add POST infrastructure and anti-forgery
+
+**Modify `BeerTaste.Web/Program.fs`:**
+- Add `AddAntiforgery()` to DI
+- Add `UseAntiforgery()` to middleware pipeline
+
+**Create `BeerTaste.Web/FormHelpers.fs`:**
+- Helper to render anti-forgery hidden input in Oxpecker views
+
+### Task 4: Wire up client-side login to server-side sessions
+
+Update the existing Firebase client code (from the branch) to exchange tokens for sessions.
+
+**Modify `BeerTaste.Web/templates/Layout.fs`:**
+- In `firebaseScripts`: after successful Google sign-in or email link callback, call `user.getIdToken()` and POST to `/auth/session`
+- On logout: POST to `/auth/logout` in addition to `firebase.auth().signOut()`
+- Auth state now driven by server-side session (cookie), not just client-side Firebase state
+
+**Modify `BeerTaste.Web/templates/Layout.fs` (nav):**
+- Show user name from server-side session (passed to template), not just client-side JS
+- Fallback: client-side JS still updates UI for immediate feedback
+
+### Task 5: Create Beer Tasting via Web
+
+First write feature — authenticated users can create a new tasting event.
+
+**Modify `BeerTaste.Common/BeerTaste.fs`:**
+- Add `AdminEmail: string` field to `BeerTaste` record
+- Update entity conversion functions
+- Update `addBeerTaste` to accept `adminEmail`
+
+**Modify `BeerTaste.Console/Workflow.fs`:**
+- Pass a hardcoded admin email to keep Console functional
+
+**Create `BeerTaste.Web/templates/CreateBeerTasteView.fs`:**
+- Form: ShortName, Description, Date → POST `/create`
+
+**Modify `BeerTaste.Web/Program.fs`:**
+- Add GET/POST `/create` (requires auth via `getCurrentUser`)
+- Homepage shows "Create New Tasting" button when logged in
+
+---
+
+## Phase 2: Beer and Taster Management
+
+### Task 6: Admin Beer Management UI
+Web forms for taste admin to add/edit/delete beers. Authorization: only the user whose email matches `AdminEmail`. Add individual `addBeer`/`deleteBeer` to Common. Invalidate DataCache on writes.
+
+### Task 7: Taster Management — Manual Mode
+Admin adds tasters (name + email) via web form. Individual `addTaster`/`deleteTaster` in Common.
+
+### Task 8: Taster Self-Registration — Kahoot Mode
+Public page at `/{beerTasteGuid}/join` — anyone with the link or QR code can register as a taster. Admin dashboard shows QR code. No auth required for this page.
+
+---
+
+## Phase 3: Scoring
+
+### Task 9: Token-Based Scoring Links
+Generate unique scoring token per taster (new column on taster entity, or separate tokens table). Email tasters a link like `/{beerTasteGuid}/score?token=xxx`. Scoring page shows all beers, taster enters scores 1-10. Individual `upsertScore` in Common.
+
+### Task 10: Admin Dashboard
+`/{beerTasteGuid}/admin` — shows beers, tasters, score completion matrix, QR code. Only visible to taste admin. Initially requires manual refresh.
+
+---
+
+## Phase 4: Live Experience
+
+### Task 11: Real-Time Dashboard
+Add SignalR (or server-sent events) to the admin dashboard. Score submissions trigger live updates.
+
+### Task 12: Beer-by-Beer Scoring Mode (optional embellishment)
+Admin controls which beer is currently active. Taster scoring page shows only the current beer. Add `CurrentBeerIndex` to the beertaste entity.
+
+---
+
+## Phase 5: Results and Polish
+
+### Task 13: Admin Publishes Results
+Add `Published` boolean to beertaste entity. Results pages return 403 for non-admins until published.
+
+### Task 14: Email Results from Web
+Move email-sending from Console to Web. "Send Results Email" button on admin dashboard. Reuse existing `Email.createBeerTasteResultsEmail` and `Email.sendEmails`.
+
+### Task 15: My Tastings Page
+`/my-tastings` — lists all tastings where current user is admin. Landing page for authenticated users.
+
+---
+
+## Phase 6: Cleanup
+
+### Task 16: Input Validation and Error Handling
+Server-side validation for all forms. Friendly error messages. Optional client-side validation.
+
+### Task 17: Cache Invalidation on Writes
+Explicit `cache.Remove(key)` after web UI writes, or shorter TTL for active tastings.
+
+### Task 18: Console Deprecation
+Mark Console features overlapping with Web as deprecated. Ensure Console compiles with updated Common types. No new Console features.
+
+---
+
+## Key Files Touched Across Plan
+
+| File | Tasks |
+|------|-------|
+| `BeerTaste.Web/Program.fs` | 1-5, 6-10, 11, 13-14 |
+| `BeerTaste.Common/Storage.fs` | 2 |
+| `BeerTaste.Common/Users.fs` (new) | 2 |
+| `BeerTaste.Common/Sessions.fs` (new) | 2 |
+| `BeerTaste.Common/BeerTaste.fs` | 5, 12, 13 |
+| `BeerTaste.Web/FirebaseAuth.fs` (new) | 2 |
+| `BeerTaste.Web/AuthMiddleware.fs` (new) | 2 |
+| `BeerTaste.Web/FormHelpers.fs` (new) | 3 |
+| `BeerTaste.Web/Localization.fs` | 5-10, 13-15 |
+| `BeerTaste.Web/templates/Layout.fs` | 4 |
+| `BeerTaste.Web/BeerTaste.Web.fsproj` | 1-5 |
+
+## Reference: HabitTeller Auth Pattern
+
+The server-side auth follows the HabitTeller repo pattern:
+- `FirebaseAuth.fs` — Firebase Admin SDK init + token verification
+- `AuthMiddleware.fs` — custom middleware checking Bearer token or session cookie
+- `POST /auth/session` — exchanges Firebase ID token for server-side session
+- `POST /auth/logout` — clears session
+- Users table: PartitionKey = `"Firebase"`, RowKey = Firebase UID
+- Sessions table: PartitionKey = first 8 chars of SessionId, RowKey = full SessionId
+- HttpOnly, Secure, SameSite=Strict cookies, 90-day expiry
+
+## Verification (per task)
+
+- Build: `dotnet build` from root (all 3 projects must compile)
+- Tests: `dotnet test BeerTaste.Tests/BeerTaste.Tests.fsproj`
+- Manual: run web app (`dotnet run --project BeerTaste.Web`) and verify existing result pages still work
+- Console: `dotnet build BeerTaste.Console/BeerTaste.Console.fsproj` (must compile after Common changes)


### PR DESCRIPTION
Each page handler previously fetched beers, tasters, and/or scores from Azure Table Storage on every request. A user navigating across the 9 result pages would trigger up to 27 separate Azure reads for identical data.

Introduce DataCache wrapping BeerTasteTableStorage with IMemoryCache (built-in ASP.NET Core, no new dependency). Cached entries expire after 10 minutes, which is well within a single tasting session. Subsequent page navigations within that window are served from the in-process cache at near-zero latency.