### PR TITLE
feat: add server-side auth infrastructure (Tasks 1-2)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,8 @@
       "Bash(powershell:*)",
       "Bash(dotnet fantomas:*)",
       "Bash(gh pr:*)",
-      "Bash(dotnet test:*)"
+      "Bash(dotnet test:*)",
+      "Bash(ls:*)"
     ],
     "deny": [],
     "ask": []

--- a/BeerTaste.Common/BeerTaste.Common.fsproj
+++ b/BeerTaste.Common/BeerTaste.Common.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="Tasters.fs" />
     <Compile Include="BeerTaste.fs" />
     <Compile Include="Users.fs" />
+    <Compile Include="Sessions.fs" />
     <Compile Include="Scores.fs" />
     <Compile Include="Email.fs" />
     <Compile Include="Results.fs" />

--- a/BeerTaste.Common/Sessions.fs
+++ b/BeerTaste.Common/Sessions.fs
@@ -1,0 +1,97 @@
+namespace BeerTaste.Common
+
+open System
+open System.Threading.Tasks
+open Azure.Data.Tables
+
+type Session = {
+    SessionId: Guid
+    UserId: Guid
+    AccountId: string
+    AuthScheme: string
+    Name: string
+    LastActiveAt: DateTimeOffset
+}
+
+module Sessions =
+    [<Literal>]
+    let SessionExpiryDays = 90.0
+
+    [<Literal>]
+    let LastActiveThresholdHours = 1.0
+
+    let isExpired (now: DateTimeOffset) (session: Session) =
+        session.LastActiveAt < now.AddDays(-SessionExpiryDays)
+
+    let shouldUpdateLastActive (now: DateTimeOffset) (session: Session) =
+        session.LastActiveAt < now.AddHours(-LastActiveThresholdHours)
+
+    let private partitionKey (sessionId: Guid) = sessionId.ToString("N").Substring(0, 8)
+
+    let sessionToEntity (session: Session) : TableEntity =
+        let entity = TableEntity(partitionKey session.SessionId, session.SessionId.ToString())
+        entity.Add("UserId", session.UserId)
+        entity.Add("AccountId", session.AccountId)
+        entity.Add("AuthScheme", session.AuthScheme)
+        entity.Add("Name", session.Name)
+        entity.Add("LastActiveAt", session.LastActiveAt)
+        entity
+
+    let entityToSession (entity: TableEntity) : Session = {
+        SessionId = entity.RowKey |> Guid.Parse
+        UserId = entity.GetGuid("UserId").Value
+        AccountId = entity.GetString("AccountId")
+        AuthScheme = entity.GetString("AuthScheme")
+        Name = entity.GetString("Name")
+        LastActiveAt = entity.GetDateTimeOffset("LastActiveAt").Value
+    }
+
+    let addSession (sessionsTable: TableClient) (session: Session) : Task =
+        task {
+            let entity = sessionToEntity session
+            let! _ = sessionsTable.UpsertEntityAsync(entity)
+            ()
+        }
+
+    let fetchSession (sessionsTable: TableClient) (sessionId: Guid) : Task<Session option> =
+        task {
+            try
+                let! response = sessionsTable.GetEntityAsync<TableEntity>(partitionKey sessionId, sessionId.ToString())
+
+                return response.Value |> entityToSession |> Some
+            with :? Azure.RequestFailedException as ex when ex.Status = 404 ->
+                return None
+        }
+
+    let deleteSession (sessionsTable: TableClient) (sessionId: Guid) : Task =
+        task {
+            try
+                let! _ = sessionsTable.DeleteEntityAsync(partitionKey sessionId, sessionId.ToString())
+
+                ()
+            with :? Azure.RequestFailedException as ex when ex.Status = 404 ->
+                ()
+        }
+
+    let authenticateSession (sessionsTable: TableClient) (sessionId: Guid) : Task<User option> =
+        task {
+            match! fetchSession sessionsTable sessionId with
+            | None -> return None
+            | Some session ->
+                let now = DateTimeOffset.UtcNow
+
+                if isExpired now session then
+                    do! deleteSession sessionsTable sessionId
+                    return None
+                else
+                    if shouldUpdateLastActive now session then
+                        do! addSession sessionsTable { session with LastActiveAt = now }
+
+                    return
+                        Some {
+                            UserId = session.UserId
+                            AccountId = session.AccountId
+                            AuthenticationScheme = session.AuthScheme
+                            Name = session.Name
+                        }
+        }

--- a/BeerTaste.Common/Sessions.fs
+++ b/BeerTaste.Common/Sessions.fs
@@ -26,11 +26,9 @@ module Sessions =
     let shouldUpdateLastActive (now: DateTimeOffset) (session: Session) =
         session.LastActiveAt < now.AddHours(-LastActiveThresholdHours)
 
-    let private partitionKey (sessionId: Guid) = sessionId.ToString("D").Substring(0, 8)
-
     let sessionToEntity (session: Session) : TableEntity =
-        let entity = TableEntity(partitionKey session.SessionId, session.SessionId.ToString())
-        entity.Add("UserId", session.UserId.ToString("D")) // Guid as string
+        let entity = TableEntity(session.SessionId.ToString(), session.SessionId.ToString())
+        entity.Add("UserId", session.UserId.ToString()) // Guid as string
         entity.Add("AccountId", session.AccountId)
         entity.Add("AuthScheme", session.AuthScheme)
         entity.Add("Name", session.Name)

--- a/BeerTaste.Common/Sessions.fs
+++ b/BeerTaste.Common/Sessions.fs
@@ -43,7 +43,9 @@ module Sessions =
         AccountId = entity.GetString("AccountId")
         AuthScheme = entity.GetString("AuthScheme")
         Name = entity.GetString("Name")
-        LastActiveAt = entity.GetString("LastActiveAt") |> DateTimeOffset.Parse
+        LastActiveAt =
+            entity.GetString("LastActiveAt")
+            |> DateTimeOffset.Parse
     }
 
     let addSession (sessionsTable: TableClient) (session: Session) : Task =

--- a/BeerTaste.Common/Sessions.fs
+++ b/BeerTaste.Common/Sessions.fs
@@ -26,24 +26,24 @@ module Sessions =
     let shouldUpdateLastActive (now: DateTimeOffset) (session: Session) =
         session.LastActiveAt < now.AddHours(-LastActiveThresholdHours)
 
-    let private partitionKey (sessionId: Guid) = sessionId.ToString("N").Substring(0, 8)
+    let private partitionKey (sessionId: Guid) = sessionId.ToString("D").Substring(0, 8)
 
     let sessionToEntity (session: Session) : TableEntity =
         let entity = TableEntity(partitionKey session.SessionId, session.SessionId.ToString())
-        entity.Add("UserId", session.UserId)
+        entity.Add("UserId", session.UserId.ToString("D")) // Guid as string
         entity.Add("AccountId", session.AccountId)
         entity.Add("AuthScheme", session.AuthScheme)
         entity.Add("Name", session.Name)
-        entity.Add("LastActiveAt", session.LastActiveAt)
+        entity.Add("LastActiveAt", session.LastActiveAt.ToString("o")) // ISO 8601 format
         entity
 
     let entityToSession (entity: TableEntity) : Session = {
         SessionId = entity.RowKey |> Guid.Parse
-        UserId = entity.GetGuid("UserId").Value
+        UserId = entity.GetString("UserId") |> Guid.Parse
         AccountId = entity.GetString("AccountId")
         AuthScheme = entity.GetString("AuthScheme")
         Name = entity.GetString("Name")
-        LastActiveAt = entity.GetDateTimeOffset("LastActiveAt").Value
+        LastActiveAt = entity.GetString("LastActiveAt") |> DateTimeOffset.Parse
     }
 
     let addSession (sessionsTable: TableClient) (session: Session) : Task =

--- a/BeerTaste.Common/Sessions.fs
+++ b/BeerTaste.Common/Sessions.fs
@@ -42,8 +42,11 @@ module Sessions =
         AuthScheme = entity.GetString("AuthScheme")
         Name = entity.GetString("Name")
         LastActiveAt =
-            entity.GetString("LastActiveAt")
-            |> DateTimeOffset.Parse
+            DateTimeOffset.ParseExact(
+                entity.GetString("LastActiveAt"),
+                "o",
+                System.Globalization.CultureInfo.InvariantCulture
+            )
     }
 
     let addSession (sessionsTable: TableClient) (session: Session) : Task =
@@ -56,7 +59,7 @@ module Sessions =
     let fetchSession (sessionsTable: TableClient) (sessionId: Guid) : Task<Session option> =
         task {
             try
-                let! response = sessionsTable.GetEntityAsync<TableEntity>(partitionKey sessionId, sessionId.ToString())
+                let! response = sessionsTable.GetEntityAsync<TableEntity>(sessionId.ToString(), sessionId.ToString())
 
                 return response.Value |> entityToSession |> Some
             with :? Azure.RequestFailedException as ex when ex.Status = 404 ->
@@ -66,7 +69,7 @@ module Sessions =
     let deleteSession (sessionsTable: TableClient) (sessionId: Guid) : Task =
         task {
             try
-                let! _ = sessionsTable.DeleteEntityAsync(partitionKey sessionId, sessionId.ToString())
+                let! _ = sessionsTable.DeleteEntityAsync(sessionId.ToString(), sessionId.ToString())
 
                 ()
             with :? Azure.RequestFailedException as ex when ex.Status = 404 ->

--- a/BeerTaste.Common/Storage.fs
+++ b/BeerTaste.Common/Storage.fs
@@ -30,11 +30,16 @@ type BeerTasteTableStorage(connectionString: string) =
     let usersTableClient = service.GetTableClient(usersTableName)
     do usersTableClient.CreateIfNotExists() |> ignore
 
+    let sessionsTableName = "sessions"
+    let sessionsTableClient = service.GetTableClient(sessionsTableName)
+    do sessionsTableClient.CreateIfNotExists() |> ignore
+
     member this.BeerTasteTableClient = beerTasteTableClient
     member this.BeersTableClient = beersTableClient
     member this.TastersTableClient = tastersTableClient
     member this.ScoresTableClient = scoresTableClient
     member this.UsersTableClient = usersTableClient
+    member this.SessionsTableClient = sessionsTableClient
 
 module Storage =
     let addEntitiesBatch (table: TableClient) (entities: TableEntity list) : Task =

--- a/BeerTaste.Common/Users.fs
+++ b/BeerTaste.Common/Users.fs
@@ -14,7 +14,7 @@ type User = {
 module Users =
     let userToEntity (user: User) : TableEntity =
         let entity = TableEntity(user.AuthenticationScheme, user.AccountId)
-        entity.Add("UserId", user.UserId)
+        entity.Add("UserId", user.UserId.ToString("D"))
         entity.Add("Name", user.Name)
         entity
 

--- a/BeerTaste.Common/Users.fs
+++ b/BeerTaste.Common/Users.fs
@@ -21,7 +21,7 @@ module Users =
     let entityToUser (entity: TableEntity) : User = {
         AuthenticationScheme = entity.PartitionKey
         AccountId = entity.RowKey
-        UserId = entity.GetGuid("UserId").Value
+        UserId = entity.GetString("UserId") |> Guid.Parse
         Name = entity.GetString("Name")
     }
 

--- a/BeerTaste.Common/Users.fs
+++ b/BeerTaste.Common/Users.fs
@@ -14,7 +14,7 @@ type User = {
 module Users =
     let userToEntity (user: User) : TableEntity =
         let entity = TableEntity(user.AuthenticationScheme, user.AccountId)
-        entity.Add("UserId", user.UserId.ToString("D"))
+        entity.Add("UserId", user.UserId.ToString())
         entity.Add("Name", user.Name)
         entity
 

--- a/BeerTaste.Tests/BeerTaste.Tests.fsproj
+++ b/BeerTaste.Tests/BeerTaste.Tests.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="ScoresTests.fs" />
     <Compile Include="ResultsTests.fs" />
     <Compile Include="CorrelationTests.fs" />
+    <Compile Include="SessionsTests.fs" />
     <Compile Include="HelperTests.fs" />
   </ItemGroup>
 

--- a/BeerTaste.Tests/SessionsTests.fs
+++ b/BeerTaste.Tests/SessionsTests.fs
@@ -77,10 +77,10 @@ module EntityRoundTripTests =
         Assert.Equal(session.LastActiveAt, roundTripped.LastActiveAt)
 
     [<Fact>]
-    let ``partition key uses first 8 chars of session id`` () =
+    let ``partition key uses session id`` () =
         let session = makeSession ()
         let entity = sessionToEntity session
-        let expected = session.SessionId.ToString("N").Substring(0, 8)
+        let expected = session.SessionId.ToString()
         Assert.Equal(expected, entity.PartitionKey)
 
     [<Fact>]

--- a/BeerTaste.Tests/SessionsTests.fs
+++ b/BeerTaste.Tests/SessionsTests.fs
@@ -1,0 +1,90 @@
+module BeerTaste.Tests.SessionsTests
+
+open System
+open Xunit
+open BeerTaste.Common
+open BeerTaste.Common.Sessions
+
+let makeSession () = {
+    SessionId = Guid.NewGuid()
+    UserId = Guid.NewGuid()
+    AccountId = "firebase-uid-123"
+    AuthScheme = "Firebase"
+    Name = "Test User"
+    LastActiveAt = DateTimeOffset(2025, 6, 15, 12, 0, 0, TimeSpan.Zero)
+}
+
+module IsExpiredTests =
+    [<Fact>]
+    let ``session active 1 day ago is not expired`` () =
+        let session = makeSession ()
+        let now = session.LastActiveAt.AddDays(1.0)
+        Assert.False(isExpired now session)
+
+    [<Fact>]
+    let ``session active 89 days ago is not expired`` () =
+        let session = makeSession ()
+        let now = session.LastActiveAt.AddDays(89.0)
+        Assert.False(isExpired now session)
+
+    [<Fact>]
+    let ``session active exactly 90 days ago is not expired`` () =
+        let session = makeSession ()
+        let now = session.LastActiveAt.AddDays(90.0)
+        Assert.False(isExpired now session)
+
+    [<Fact>]
+    let ``session active 91 days ago is expired`` () =
+        let session = makeSession ()
+        let now = session.LastActiveAt.AddDays(91.0)
+        Assert.True(isExpired now session)
+
+module ShouldUpdateLastActiveTests =
+    [<Fact>]
+    let ``should not update if last active 30 minutes ago`` () =
+        let session = makeSession ()
+        let now = session.LastActiveAt.AddMinutes(30.0)
+        Assert.False(shouldUpdateLastActive now session)
+
+    [<Fact>]
+    let ``should not update if last active exactly 1 hour ago`` () =
+        let session = makeSession ()
+        let now = session.LastActiveAt.AddHours(1.0)
+        Assert.False(shouldUpdateLastActive now session)
+
+    [<Fact>]
+    let ``should update if last active more than 1 hour ago`` () =
+        let session = makeSession ()
+        let now = session.LastActiveAt.AddHours(1.0).AddSeconds(1.0)
+        Assert.True(shouldUpdateLastActive now session)
+
+    [<Fact>]
+    let ``should update if last active 1 day ago`` () =
+        let session = makeSession ()
+        let now = session.LastActiveAt.AddDays(1.0)
+        Assert.True(shouldUpdateLastActive now session)
+
+module EntityRoundTripTests =
+    [<Fact>]
+    let ``session survives entity round-trip`` () =
+        let session = makeSession ()
+        let roundTripped = session |> sessionToEntity |> entityToSession
+        Assert.Equal(session.SessionId, roundTripped.SessionId)
+        Assert.Equal(session.UserId, roundTripped.UserId)
+        Assert.Equal(session.AccountId, roundTripped.AccountId)
+        Assert.Equal(session.AuthScheme, roundTripped.AuthScheme)
+        Assert.Equal(session.Name, roundTripped.Name)
+        Assert.Equal(session.LastActiveAt, roundTripped.LastActiveAt)
+
+    [<Fact>]
+    let ``partition key uses first 8 chars of session id`` () =
+        let session = makeSession ()
+        let entity = sessionToEntity session
+        let expected = session.SessionId.ToString("N").Substring(0, 8)
+        Assert.Equal(expected, entity.PartitionKey)
+
+    [<Fact>]
+    let ``row key is full session id`` () =
+        let session = makeSession ()
+        let entity = sessionToEntity session
+        Assert.Equal(session.SessionId.ToString(), entity.RowKey)

--- a/BeerTaste.Web/AuthMiddleware.fs
+++ b/BeerTaste.Web/AuthMiddleware.fs
@@ -1,0 +1,44 @@
+module BeerTaste.Web.AuthMiddleware
+
+open System
+open System.Threading.Tasks
+open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.DependencyInjection
+open BeerTaste.Common
+open BeerTaste.Common.Sessions
+
+[<Literal>]
+let AuthSchemeFirebase = "Firebase"
+
+[<Literal>]
+let CurrentUserKey = "CurrentUser"
+
+[<Literal>]
+let SessionCookieName = "session"
+
+let private extractSessionCookieId (ctx: HttpContext) : Guid option =
+    match ctx.Request.Cookies.TryGetValue(SessionCookieName) with
+    | true, value when not (String.IsNullOrEmpty(value)) ->
+        match Guid.TryParse(value) with
+        | true, guid -> Some guid
+        | false, _ -> None
+    | _ -> None
+
+let getCurrentUser (ctx: HttpContext) : User option =
+    match ctx.Items.TryGetValue(CurrentUserKey) with
+    | true, (:? User as user) -> Some user
+    | _ -> None
+
+let sessionAuthMiddleware (next: RequestDelegate) (ctx: HttpContext) : Task =
+    task {
+        let storage = ctx.RequestServices.GetRequiredService<BeerTasteTableStorage>()
+
+        match extractSessionCookieId ctx with
+        | Some sessionId ->
+            match! authenticateSession storage.SessionsTableClient sessionId with
+            | Some user -> ctx.Items[CurrentUserKey] <- user
+            | None -> ()
+        | None -> ()
+
+        do! next.Invoke(ctx)
+    }

--- a/BeerTaste.Web/BeerTaste.Web.fsproj
+++ b/BeerTaste.Web/BeerTaste.Web.fsproj
@@ -24,6 +24,8 @@
         <Compile Include="templates/TastersView.fs"/>
         <Compile Include="templates/ScoresView.fs"/>
         <Compile Include="templates/BeerTasteView.fs"/>
+        <Compile Include="FirebaseAuth.fs"/>
+        <Compile Include="AuthMiddleware.fs"/>
         <Compile Include="Program.fs"/>
         <Content Include="README.md" />
     </ItemGroup>
@@ -33,6 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="FirebaseAdmin" Version="3.5.0" />
         <PackageReference Include="Oxpecker" Version="2.0.0" />
         <PackageReference Update="FSharp.Core" Version="10.1.201" />
     </ItemGroup>

--- a/BeerTaste.Web/FirebaseAuth.fs
+++ b/BeerTaste.Web/FirebaseAuth.fs
@@ -68,7 +68,8 @@ let verifyIdToken (idToken: string) : Task<Result<VerifiedToken, string>> =
                     Name = claim "name"
                     EmailVerified =
                         match decoded.Claims.TryGetValue("email_verified") with
-                        | true, value -> value :?> bool
+                        | true, (:? bool as b) -> b
+                        | true, value -> value.ToString() |> Boolean.TryParse |> snd
                         | false, _ -> false
                 }
         with :? FirebaseAuthException as ex ->

--- a/BeerTaste.Web/FirebaseAuth.fs
+++ b/BeerTaste.Web/FirebaseAuth.fs
@@ -71,6 +71,6 @@ let verifyIdToken (idToken: string) : Task<Result<VerifiedToken, string>> =
                         | true, value -> value :?> bool
                         | false, _ -> false
                 }
-        with ex ->
+        with :? FirebaseAuthException as ex ->
             return Error $"Token verification failed: {ex.Message}"
     }

--- a/BeerTaste.Web/FirebaseAuth.fs
+++ b/BeerTaste.Web/FirebaseAuth.fs
@@ -1,0 +1,76 @@
+module BeerTaste.Web.FirebaseAuth
+
+#nowarn "44" // GoogleCredential.FromFile deprecated but CredentialFactory replacement not yet available
+
+open System
+open System.IO
+open System.Threading.Tasks
+open FirebaseAdmin
+open FirebaseAdmin.Auth
+open Microsoft.Extensions.Configuration
+
+type VerifiedToken = {
+    Uid: string
+    Email: string option
+    Name: string option
+    EmailVerified: bool
+}
+
+let readProjectId (config: IConfiguration) : string =
+    match
+        config["BeerTaste:Firebase:ProjectId"]
+        |> Option.ofObj
+    with
+    | Some id -> id
+    | None -> failwith "Missing required configuration 'BeerTaste:Firebase:ProjectId'"
+
+let initialize (config: IConfiguration) =
+    let projectId = readProjectId config
+
+    let serviceAccountKeyPath =
+        config["BeerTaste:Firebase:ServiceAccountKeyPath"]
+        |> Option.ofObj
+        |> Option.filter (String.IsNullOrEmpty >> not)
+
+    let credential =
+        match serviceAccountKeyPath with
+        | Some path when File.Exists(path) -> Google.Apis.Auth.OAuth2.GoogleCredential.FromFile(path)
+        | Some path -> failwith $"Firebase service account key file not found: {path}"
+        | None ->
+            match
+                Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS")
+                |> Option.ofObj
+            with
+            | Some envPath when File.Exists(envPath) -> Google.Apis.Auth.OAuth2.GoogleCredential.GetApplicationDefault()
+            | Some envPath -> failwith $"GOOGLE_APPLICATION_CREDENTIALS file not found: {envPath}"
+            | None ->
+                failwith
+                    "No Firebase credentials configured (no ServiceAccountKeyPath or GOOGLE_APPLICATION_CREDENTIALS)"
+
+    let appOptions = AppOptions(Credential = credential)
+    appOptions.ProjectId <- projectId
+    FirebaseApp.Create(appOptions) |> ignore
+
+let verifyIdToken (idToken: string) : Task<Result<VerifiedToken, string>> =
+    task {
+        try
+            let! decoded = FirebaseAuth.DefaultInstance.VerifyIdTokenAsync(idToken)
+
+            let claim key =
+                match decoded.Claims.TryGetValue(key) with
+                | true, value -> Some(string value)
+                | false, _ -> None
+
+            return
+                Ok {
+                    Uid = decoded.Uid
+                    Email = claim "email"
+                    Name = claim "name"
+                    EmailVerified =
+                        match decoded.Claims.TryGetValue("email_verified") with
+                        | true, value -> value :?> bool
+                        | false, _ -> false
+                }
+        with ex ->
+            return Error $"Token verification failed: {ex.Message}"
+    }

--- a/BeerTaste.Web/Program.fs
+++ b/BeerTaste.Web/Program.fs
@@ -5,11 +5,15 @@ open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.Caching.Memory
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.Hosting
 open Microsoft.Extensions.Logging
 open Oxpecker
 open Oxpecker.ViewEngine
 open Oxpecker.ViewEngine.Aria
 open BeerTaste.Common
+open BeerTaste.Common.Sessions
+open BeerTaste.Web
+open BeerTaste.Web.AuthMiddleware
 open BeerTaste.Web.Templates
 open BeerTaste.Web.Localization
 
@@ -202,9 +206,108 @@ let beerTasteView (dc: DataCache) (firebaseConfig: FirebaseConfig option) (beerT
         | None -> "BeerTaste not found" |> notFound <| ctx
 
 
+type SessionRequest = { idToken: string }
+
+[<Literal>]
+let SessionDays = 90.0
+
+let getAuthMe: EndpointHandler =
+    fun ctx ->
+        task {
+            match getCurrentUser ctx with
+            | Some user ->
+                return!
+                    ctx.WriteJsonChunked(
+                        {|
+                            userId = user.UserId
+                            name = user.Name
+                            authScheme = user.AuthenticationScheme
+                        |}
+                    )
+            | None ->
+                ctx.SetStatusCode 401
+                return! ctx.WriteJsonChunked({| error = "Not authenticated" |})
+        }
+
+let postAuthSession: EndpointHandler =
+    fun ctx ->
+        task {
+            let! bodyResult =
+                task {
+                    try
+                        match! ctx.Request.ReadFromJsonAsync<SessionRequest>() with
+                        | null -> return Error "Invalid request"
+                        | body -> return Ok body
+                    with _ ->
+                        return Error "Invalid request"
+                }
+
+            match bodyResult with
+            | Error msg ->
+                ctx.SetStatusCode 400
+                return! ctx.WriteJsonChunked({| error = msg |})
+            | Ok body ->
+                match! FirebaseAuth.verifyIdToken body.idToken with
+                | Error msg ->
+                    ctx.SetStatusCode 401
+                    return! ctx.WriteJsonChunked({| error = msg |})
+                | Ok verifiedToken ->
+                    let storage = ctx.RequestServices.GetRequiredService<BeerTasteTableStorage>()
+                    let isDevelopment = ctx.RequestServices.GetRequiredService<IHostEnvironment>().IsDevelopment()
+
+                    let name =
+                        verifiedToken.Name
+                        |> Option.defaultValue (verifiedToken.Email |> Option.defaultValue "User")
+
+                    let! user = Users.getOrCreateUser storage.UsersTableClient AuthSchemeFirebase verifiedToken.Uid name
+
+                    let sessionId = Guid.NewGuid()
+                    let now = DateTimeOffset.UtcNow
+
+                    let session = {
+                        SessionId = sessionId
+                        UserId = user.UserId
+                        AccountId = verifiedToken.Uid
+                        AuthScheme = AuthSchemeFirebase
+                        Name = user.Name
+                        LastActiveAt = now
+                    }
+
+                    do! addSession storage.SessionsTableClient session
+
+                    let cookieOptions =
+                        CookieOptions(
+                            HttpOnly = true,
+                            Secure = not isDevelopment,
+                            SameSite = SameSiteMode.Strict,
+                            Path = "/",
+                            Expires = now.AddDays(SessionDays)
+                        )
+
+                    ctx.Response.Cookies.Append(SessionCookieName, sessionId.ToString(), cookieOptions)
+                    return! ctx.WriteJsonChunked({| success = true |})
+        }
+
+let postAuthLogout: EndpointHandler =
+    fun ctx ->
+        task {
+            match ctx.Request.Cookies.TryGetValue(SessionCookieName) with
+            | true, cookieValue ->
+                match Guid.TryParse(cookieValue) with
+                | true, sessionId ->
+                    let storage = ctx.RequestServices.GetRequiredService<BeerTasteTableStorage>()
+                    do! deleteSession storage.SessionsTableClient sessionId
+                | false, _ -> ()
+            | false, _ -> ()
+
+            ctx.Response.Cookies.Delete(SessionCookieName)
+            return! ctx.WriteJsonChunked({| success = true |})
+        }
+
 let endpoints dc firebaseConfig = [
     GET [
         route "/" <| homepage firebaseConfig
+        route "/auth/me" getAuthMe
         routef "/{%s}/results" (resultsIndex firebaseConfig)
         routef "/{%s}/results/bestbeers" (bestBeers dc firebaseConfig)
         routef "/{%s}/results/controversial" (controversial dc firebaseConfig)
@@ -217,6 +320,10 @@ let endpoints dc firebaseConfig = [
         routef "/{%s}/tasters" (tastersView dc firebaseConfig)
         routef "/{%s}/scores" (scoresView dc firebaseConfig)
         routef "/{%s}" (beerTasteView dc firebaseConfig)
+    ]
+    POST [
+        route "/auth/session" postAuthSession
+        route "/auth/logout" postAuthLogout
     ]
 ]
 
@@ -259,7 +366,12 @@ let errorHandler (ctx: HttpContext) (next: RequestDelegate) : Task =
     }
 
 let configureApp (appBuilder: WebApplication) (dc: DataCache) firebaseConfig =
-    appBuilder.Use(errorHandler).UseStaticFiles().UseRouting().UseOxpecker(endpoints dc firebaseConfig)
+    appBuilder
+        .Use(errorHandler)
+        .UseStaticFiles()
+        .Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next -> sessionAuthMiddleware next ctx))
+        .UseRouting()
+        .UseOxpecker(endpoints dc firebaseConfig)
     |> ignore
 
 [<EntryPoint>]
@@ -286,6 +398,8 @@ let main args =
             .AddMemoryCache()
             .AddSingleton<BeerTasteTableStorage>(BeerTasteTableStorage(connStr))
         |> ignore
+
+        FirebaseAuth.initialize config
 
         let app = builder.Build()
         let storage = app.Services.GetRequiredService<BeerTasteTableStorage>()

--- a/BeerTaste.Web/Program.fs
+++ b/BeerTaste.Web/Program.fs
@@ -268,11 +268,6 @@ let main args =
 
     let config = builder.Configuration.AddUserSecrets<SecretsAnchor>().AddEnvironmentVariables().Build()
 
-    builder.Services.AddRouting().AddOxpecker().AddMemoryCache()
-    |> ignore
-
-    let app = builder.Build()
-
     match
         config["BeerTaste:TableStorageConnectionString"]
         |> Option.ofObj
@@ -285,7 +280,15 @@ let main args =
 
         1
     | Some connStr ->
-        let storage = BeerTasteTableStorage(connStr)
+        builder.Services
+            .AddRouting()
+            .AddOxpecker()
+            .AddMemoryCache()
+            .AddSingleton<BeerTasteTableStorage>(BeerTasteTableStorage(connStr))
+        |> ignore
+
+        let app = builder.Build()
+        let storage = app.Services.GetRequiredService<BeerTasteTableStorage>()
         let cache = app.Services.GetRequiredService<IMemoryCache>()
         let dc = DataCache(storage, cache)
         let firebaseConfig = getFirebaseConfig config

--- a/BeerTaste.Web/Program.fs
+++ b/BeerTaste.Web/Program.fs
@@ -208,9 +208,6 @@ let beerTasteView (dc: DataCache) (firebaseConfig: FirebaseConfig option) (beerT
 
 type SessionRequest = { idToken: string }
 
-[<Literal>]
-let SessionDays = 90.0
-
 let getAuthMe: EndpointHandler =
     fun ctx ->
         task {
@@ -281,7 +278,7 @@ let postAuthSession: EndpointHandler =
                             Secure = not isDevelopment,
                             SameSite = SameSiteMode.Strict,
                             Path = "/",
-                            Expires = now.AddDays(SessionDays)
+                            Expires = now.AddDays(SessionExpiryDays)
                         )
 
                     ctx.Response.Cookies.Append(SessionCookieName, sessionId.ToString(), cookieOptions)

--- a/BeerTaste.Web/Program.fs
+++ b/BeerTaste.Web/Program.fs
@@ -300,7 +300,7 @@ let postAuthLogout: EndpointHandler =
                 | false, _ -> ()
             | false, _ -> ()
 
-            ctx.Response.Cookies.Delete(SessionCookieName)
+            ctx.Response.Cookies.Delete(SessionCookieName, CookieOptions(Path = "/"))
             return! ctx.WriteJsonChunked({| success = true |})
         }
 

--- a/BeerTaste.Web/Program.fs
+++ b/BeerTaste.Web/Program.fs
@@ -379,6 +379,7 @@ let main args =
     let builder = WebApplication.CreateBuilder(args)
 
     let config = builder.Configuration.AddUserSecrets<SecretsAnchor>().AddEnvironmentVariables().Build()
+
     match
         config["BeerTaste:TableStorageConnectionString"]
         |> Option.ofObj
@@ -392,11 +393,8 @@ let main args =
         1
     | Some connStr ->
         let storage = BeerTasteTableStorage(connStr)
-        builder.Services
-            .AddRouting()
-            .AddOxpecker()
-            .AddMemoryCache()
-            .AddSingleton(storage)
+
+        builder.Services.AddRouting().AddOxpecker().AddMemoryCache().AddSingleton(storage)
         |> ignore
 
         FirebaseAuth.initialize config

--- a/PLAN.md
+++ b/PLAN.md
@@ -29,15 +29,13 @@ Already done on this branch:
 
 ## Phase 1: Foundation — Server-Side Auth (builds on existing branch)
 
-### Task 1: Move BeerTasteTableStorage and DataCache into DI
+### Task 1: Register BeerTasteTableStorage in DI
 
-Pure refactor. Currently these are manually instantiated in `main` and threaded through as parameters. Moving them to DI is prerequisite for auth middleware and new services.
+Register `BeerTasteTableStorage` as a DI singleton so that auth middleware (Task 2) can resolve it. Keep `DataCache` threaded to handlers via partial application — that's idiomatic F# with explicit, type-safe dependencies. No need for the service locator pattern (`ctx.GetService<DataCache>()`) in handlers.
 
 **Modify `BeerTaste.Web/Program.fs`:**
 - Register `BeerTasteTableStorage` as singleton (from connection string config)
-- Register `DataCache` as singleton (depends on storage + IMemoryCache)
-- Remove `dc` / `storage` parameters from `endpoints` and `configureApp`
-- Each handler resolves `DataCache` via `ctx.GetService<DataCache>()`
+- Keep `DataCache` instantiated in `main` and passed to handlers as-is
 
 No user-visible changes.
 
@@ -47,10 +45,10 @@ Follow the HabitTeller pattern: Firebase ID tokens are exchanged for server-side
 
 **Add `FirebaseAdmin` NuGet package** to `BeerTaste.Web/BeerTaste.Web.fsproj`
 
-**Create `BeerTaste.Common/Users.fs`** (new file, add to `.fsproj` between `BeerTaste.fs` and `Scores.fs`):
-- `User` record: `AuthenticationScheme: string`, `AccountId: string` (Firebase UID), `UserId: Guid`, `Name: string`
-- Entity conversion: PartitionKey = AuthenticationScheme (e.g. `"Firebase"`), RowKey = AccountId
-- `addUser`, `fetchUser`, `getOrCreateUser`
+**~~Create `BeerTaste.Common/Users.fs`~~** ✅ Done
+- `User` record with `AuthenticationScheme`, `AccountId`, `UserId`, `Name`
+- Entity conversion (PartitionKey = AuthenticationScheme, RowKey = AccountId)
+- `addUser`, `fetchUser`, `getOrCreateUser` (with 409 conflict handling)
 
 **Create `BeerTaste.Common/Sessions.fs`** (new file, after Users.fs):
 - `Session` record: `SessionId: Guid`, `UserId: Guid`, `AccountId: string`, `AuthScheme: string`, `Name: string`, `LastActiveAt: DateTimeOffset`
@@ -59,7 +57,8 @@ Follow the HabitTeller pattern: Firebase ID tokens are exchanged for server-side
 - Session expiry: 90 days, update `LastActiveAt` only if >1 hour old
 
 **Modify `BeerTaste.Common/Storage.fs`:**
-- Add `UsersTableClient` and `SessionsTableClient` (tables: `"users"`, `"sessions"`)
+- ~~Add `UsersTableClient`~~ ✅ Done
+- Add `SessionsTableClient` (table: `"sessions"`)
 
 **Create `BeerTaste.Web/FirebaseAuth.fs`** (before Program.fs in compilation):
 - `FirebaseServerConfig` type: `ProjectId`, optional `ServiceAccountKeyPath`

--- a/PLAN.md
+++ b/PLAN.md
@@ -39,9 +39,9 @@ Register `BeerTasteTableStorage` as a DI singleton so that auth middleware (Task
 
 No user-visible changes.
 
-### Task 2: Add Users, Sessions tables and server-side auth middleware
+### Task 2: Add Sessions table, server-side auth middleware, and auth endpoints
 
-Follow the HabitTeller pattern: Firebase ID tokens are exchanged for server-side sessions stored in Azure Table Storage.
+Firebase ID tokens are exchanged for server-side sessions stored in Azure Table Storage. Browser-only — no Bearer token support (add later if needed).
 
 **Add `FirebaseAdmin` NuGet package** to `BeerTaste.Web/BeerTaste.Web.fsproj`
 
@@ -53,29 +53,31 @@ Follow the HabitTeller pattern: Firebase ID tokens are exchanged for server-side
 **Create `BeerTaste.Common/Sessions.fs`** (new file, after Users.fs):
 - `Session` record: `SessionId: Guid`, `UserId: Guid`, `AccountId: string`, `AuthScheme: string`, `Name: string`, `LastActiveAt: DateTimeOffset`
 - Entity conversion: PartitionKey = first 8 chars of SessionId, RowKey = full SessionId
-- `addSession`, `fetchSession`, `deleteSession`, `updateLastActiveAt`
-- Session expiry: 90 days, update `LastActiveAt` only if >1 hour old
+- `addSession`, `fetchSession`, `deleteSession`
+- Pure expiry functions: `isExpired` (90 days), `shouldUpdateLastActive` (>1 hour since last update)
+- `authenticateSession`: fetch → check expiry (delete if expired) → update LastActiveAt if stale → return `User option`
 
 **Modify `BeerTaste.Common/Storage.fs`:**
 - ~~Add `UsersTableClient`~~ ✅ Done
 - Add `SessionsTableClient` (table: `"sessions"`)
 
 **Create `BeerTaste.Web/FirebaseAuth.fs`** (before Program.fs in compilation):
-- `FirebaseServerConfig` type: `ProjectId`, optional `ServiceAccountKeyPath`
-- `initialize()`: sets up FirebaseAdmin SDK
-- `verifyIdToken(token)`: validates Firebase ID token, returns claims
+- `VerifiedToken` record: `Uid: string`, `Email: string option`, `Name: string option`, `EmailVerified: bool`
+- `initialize(projectId)`: sets up FirebaseAdmin SDK, fail fast if not configured
+- `verifyIdToken(token) -> Task<Result<VerifiedToken, string>>`
 
 **Create `BeerTaste.Web/AuthMiddleware.fs`** (after FirebaseAuth.fs):
-- Custom middleware following HabitTeller pattern:
-  - Path 1: `Authorization: Bearer <token>` → verify with Firebase → get/create user → set in `HttpContext.Items`
-  - Path 2: `session` cookie → lookup in sessions table → validate expiry → set user in `HttpContext.Items`
-- Helper: `getCurrentUser(ctx)` returns `User option`
+- Session-cookie-only middleware:
+  - Read `session` cookie → call `Sessions.authenticateSession` → set `User` in `HttpContext.Items`
+- `getCurrentUser(ctx) -> User option` helper
 
 **Modify `BeerTaste.Web/Program.fs`:**
-- Add auth middleware to pipeline
-- Add `POST /auth/session` endpoint: accepts Firebase ID token, creates session, sets HttpOnly cookie
-- Add `POST /auth/logout` endpoint: deletes session, clears cookie
+- Fail fast if Firebase config (`ProjectId`) is missing
 - Initialize Firebase Admin SDK on startup
+- Add auth middleware to pipeline (before routing)
+- Add `POST /auth/session`: accepts Firebase ID token, verifies via FirebaseAdmin, gets/creates user, creates session, sets HttpOnly cookie (`Secure = not isDevelopment`, `SameSite = Strict`, 90-day expiry)
+- Add `POST /auth/logout`: reads session cookie, deletes session, clears cookie
+- Add `GET /auth/me`: returns authenticated user info or 401
 
 ### Task 3: Add POST infrastructure and anti-forgery
 


### PR DESCRIPTION
## Summary

- **Task 1:** Register `BeerTasteTableStorage` as DI singleton for middleware access
- **Task 2:** Add Sessions table, Firebase server-side auth, and session-cookie middleware
  - `Sessions.fs` in Common — Session record, pure expiry functions, entity conversion, CRUD, `authenticateSession`
  - `FirebaseAuth.fs` in Web — Firebase Admin SDK init (fail fast), `VerifiedToken` type, `verifyIdToken`
  - `AuthMiddleware.fs` in Web — session-cookie middleware, `getCurrentUser` helper
  - Auth endpoints: `POST /auth/session`, `POST /auth/logout`, `GET /auth/me`
- **Tests:** 11 new tests for session expiry logic and entity round-tripping (70 total)
- **Plan updates:** Marked Users table done, refined Task 1 scope, updated Task 2 with design decisions

## New files
- `BeerTaste.Common/Sessions.fs`
- `BeerTaste.Web/FirebaseAuth.fs`
- `BeerTaste.Web/AuthMiddleware.fs`
- `BeerTaste.Tests/SessionsTests.fs`

## Design decisions
- **No Bearer token support** — session cookies only (browser-first app)
- **DI only for `BeerTasteTableStorage`** — `DataCache` stays threaded via partial application (idiomatic F#)
- **Fail fast** if Firebase not configured
- **Cookie `Secure` flag** conditional on environment for local dev

## Test plan
- [x] `dotnet build` — zero warnings, zero errors
- [x] `dotnet test` — 70 tests pass (59 existing + 11 new)
- [x] `dotnet fantomas . --check` — formatting clean
- [ ] Manual: run web app and verify existing result pages still work
- [ ] Manual: verify Firebase login creates server-side session

🤖 Generated with [Claude Code](https://claude.com/claude-code)